### PR TITLE
Add build script

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+audit-level = high

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - "lts/*"
+script:
+  - npm audit
+branches:
+  except:
+  - master


### PR DESCRIPTION
The build will fail if it finds security vulnerabilities of level high and up.
This means our current low vulnerabilities (63 of them) will not break the build.

Examples: see the last two commits on this [demo branch](https://github.com/serra/CoderdojoDelft.github.io/commits/build-script).

![image](https://user-images.githubusercontent.com/285398/54021376-52195a00-4190-11e9-88de-5c2ec06b637b.png)


