### PR TITLE
coderdojo url of DOK / package updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15416,6 +15416,11 @@
                 "camelcase": "^5.0.0",
                 "decamelize": "^1.2.0"
             }
+        },
+        "yarn": {
+            "version": "1.21.1",
+            "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.21.1.tgz",
+            "integrity": "sha512-dQgmJv676X/NQczpbiDtc2hsE/pppGDJAzwlRiADMTvFzYbdxPj2WO4PcNyriSt2c4jsCMpt8UFRKHUozt21GQ=="
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
         "react-dom": "^16.12.0",
         "react-router-dom": "^4.3.1",
         "react-scripts": "^3.3.0",
-        "styled-components": "^4.4.1"
+        "styled-components": "^4.4.1",
+        "yarn": "^1.21.1"
     },
     "scripts": {
         "start": "react-scripts start",

--- a/src/content/next-edition.js
+++ b/src/content/next-edition.js
@@ -10,73 +10,73 @@ export const nextEditions = ((today) => {
             date: new Date(2020, 0, 25),
             displayDate: 'zaterdag 25 januari 2020',
             registrationStart: 'zondag 12 januari 2020',
-            registrationUrl: 'https://www.dok.info/home.html'
+            registrationUrl: 'https://www.dok.info/jeugd/coderdojo.html'
         },
         {
             date: new Date(2020, 1, 22),
             displayDate: 'zaterdag 22 februari 2020',
             registrationStart: 'zondag 9 februari 2020',
-            registrationUrl: 'https://www.dok.info/home.html'
+            registrationUrl: 'https://www.dok.info/jeugd/coderdojo.html'
         },
         {
             date: new Date(2020, 2, 28),
             displayDate: 'zaterdag 28 maart 2020',
             registrationStart: 'zondag 15 maart 2020',
-            registrationUrl: 'https://www.dok.info/home.html'
+            registrationUrl: 'https://www.dok.info/jeugd/coderdojo.html'
         },
         {
             date: new Date(2020, 3, 25),
             displayDate: 'zaterdag 25 april 2020',
             registrationStart: 'zondag 12 april 2020',
-            registrationUrl: 'https://www.dok.info/home.html'
+            registrationUrl: 'https://www.dok.info/jeugd/coderdojo.html'
         },
         {
             date: new Date(2020, 4, 23),
             displayDate: 'zaterdag 23 mei 2020',
             registrationStart: 'zondag 10 mei 2020',
-            registrationUrl: 'https://www.dok.info/home.html'
+            registrationUrl: 'https://www.dok.info/jeugd/coderdojo.html'
         },
         {
             date: new Date(2020, 5, 27),
             displayDate: 'zaterdag 27 juni 2020',
             registrationStart: 'zondag 14 juni 2020',
-            registrationUrl: 'https://www.dok.info/home.html'
+            registrationUrl: 'https://www.dok.info/jeugd/coderdojo.html'
         },
         {
             date: new Date(2020, 6, 25),
             displayDate: 'zaterdag 25 juli 2020',
             registrationStart: 'zondag 12 juli 2020',
-            registrationUrl: 'https://www.dok.info/home.html'
+            registrationUrl: 'https://www.dok.info/jeugd/coderdojo.html'
         },
         {
             date: new Date(2020, 7, 22),
             displayDate: 'zaterdag 22 augustus 2020',
             registrationStart: 'zondag 9 augustus 2020',
-            registrationUrl: 'https://www.dok.info/home.html'
+            registrationUrl: 'https://www.dok.info/jeugd/coderdojo.html'
         },
         {
             date: new Date(2020, 8, 26),
             displayDate: 'zaterdag 26 september 2020',
             registrationStart: 'zondag 13 september 2020',
-            registrationUrl: 'https://www.dok.info/home.html'
+            registrationUrl: 'https://www.dok.info/jeugd/coderdojo.html'
         },
         {
             date: new Date(2020, 9, 24),
             displayDate: 'zaterdag 24 oktober 2020',
             registrationStart: 'zondag 11 okotber 2020',
-            registrationUrl: 'https://www.dok.info/home.html'
+            registrationUrl: 'https://www.dok.info/jeugd/coderdojo.html'
         },
         {
             date: new Date(2020, 10, 28),
             displayDate: 'zaterdag 28 november 2020',
             registrationStart: 'zondag 15 november 2020',
-            registrationUrl: 'https://www.dok.info/home.html'
+            registrationUrl: 'https://www.dok.info/jeugd/coderdojo.html'
         },
         {
             date: new Date(2020, 11, 19),
             displayDate: 'zaterdag 19 december 2020',
             registrationStart: 'zondag 3 december 2020',
-            registrationUrl: 'https://www.dok.info/home.html'
+            registrationUrl: 'https://www.dok.info/jeugd/coderdojo.html'
         },
     ].filter((edition) => {
         return edition.date.getTime() > today.getTime();

--- a/src/page/NextEditionPage.js
+++ b/src/page/NextEditionPage.js
@@ -51,7 +51,7 @@ export class NextEditionPage extends Component {
                 <p>We hebben een beperkt aantal laptops te leen. Laat het ons via het inschrijfformulier weten als je daarvan gebruik wilt maken.</p>
                 <h3>Inschrijven</h3>
                 <p>Voor deze Dojo hebben we maar beperkt plek! Er is ruimte voor een maximaal aantal deelnemers. Elke deelnemer heeft zijn eigen ticket nodig, en je kunt maximaal twee tickets reserveren. Als de plekken voor deze CoderDojo bezet zijn, kun je je naam op de wachtlijst zetten, we nemen dan contact met je op zodra er een plek vrijkomt. Laat het ons dus ook weten als je verhinderd bent.</p>
-                <p>Vanaf januari 2020 wordt de inschrijving verzorgt door DOK. De directe link naar het inschrijfformulier is nog niet bekend, je wordt doorverwezen naar de algemene site van DOK.</p>
+                <p>Vanaf januari 2020 wordt de inschrijving verzorgt door DOK. Indien onderstaande scherm niet werkt, kun je je aanmelden <a href={nextEdition.registrationUrl} target="_blank" rel="noopener noreferrer">via deze link naar DOK</a></p>
                 <iframe title="registration" src={nextEdition.registrationUrl} width="100%" height="500" frameBorder="0" marginWidth="5" marginHeight="5" />
                 <p><i>Is de Dojo vol, of kun je niet op die dag? Je kunt ook kijken of er plek is bij een CoderDojo in de buurt: <a href="http://www.coderdojo-zoetermeer.nl" target="_blank" rel="noopener noreferrer">CoderDojo Zoetermeer</a>,  <a href="http://www.coderdojo-denhaag.nl" target="_blank" rel="noopener noreferrer">CoderDojo Den Haag</a> of <a href="http://www.coderdojo-rotterdam.nl" target="_blank" rel="noopener noreferrer">CoderDojo Rotterdam</a>.</i></p>
             </React.Fragment>


### PR DESCRIPTION
Ik heb de URL naar de website van DOK aangepast, zodat ie naar de Coderdojo-info gaat. Inschrijven lijkt altijd via dezelfde pagina te gaan. Via de kalender is er wel steeds een andere, maar voor inschrijven kom je steeds weer op de main page uit. 
Iframe doet het alleen niet voor Dok-site. Dat zal wel met instellingen van DOK te maken hebben over hun site en kunnen wij denk ik niet oplossen (?)